### PR TITLE
Fix installer issues

### DIFF
--- a/pyvista_gui/gui.py
+++ b/pyvista_gui/gui.py
@@ -10,7 +10,8 @@ from PyQt5.QtWidgets import (QAction, QDockWidget, QHBoxLayout,
                              QMainWindow, QMenu, QMessageBox, QProgressDialog,
                              QSizePolicy, QSplitter, QVBoxLayout)
 
-from pyvista.plotting import Plotter, QtInteractor
+from pyvista.plotting import Plotter
+from pyvistaqt import QtInteractor
 
 from pyvista_gui.console import QIPythonWidget
 from pyvista_gui.data import Data
@@ -117,7 +118,7 @@ class GUIWindow(QMainWindow):
             self.resizeDocks([self.dock_vtk, self.dock_tree], [4, 1],
                              Qt.Horizontal)
 
-            self.plotter.add_toolbars(self)
+            # self.plotter.add_toolbars(self)
 
         self.tabifyDockWidget(self.dock_console, self.dock_commands)
         self.tabifyDockWidget(self.dock_commands, self.dock_logger)

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,12 @@ with io_open(version_file, mode='r') as fd:
 
 # pre-compiled vtk available for python3
 install_requires = ['pyvista>=0.22.4',
-                    'PyQt5==5.11.3',
+                    'PyQt5>=5.11.3',
                     'scooby>=0.2.2',
                     'matplotlib',
+                    'pyvistaqt',
+                    'qdarkstyle',
+                    'qtconsole'
                     ]
 
 # add vtk if not windows and 2.7


### PR DESCRIPTION
Please, consider and check these changes to allow running pyvista-gui with newer Qt5 version and using pyvistaqt as an interactor